### PR TITLE
data workflow: use pipenv install of requirements.txt

### DIFF
--- a/.github/workflows/data-workflow.yml
+++ b/.github/workflows/data-workflow.yml
@@ -5,7 +5,6 @@ on:
     - cron: "23 19 * * *"
   workflow_dispatch:
 
-
 jobs:
   data_workflow:
     runs-on: ubuntu-latest
@@ -22,12 +21,12 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r data-workflow/requirements.txt
+          python -m pip install pipenv --user
+          pipenv install
       - name: Run Workflow
         run: |
-          python data-workflow/main.py
-  
+          pipenv run python data-workflow/main.py
+
   data_validation:
     needs: data_workflow
     runs-on: ubuntu-latest

--- a/data-workflow/requirements.txt
+++ b/data-workflow/requirements.txt
@@ -1,5 +1,0 @@
-google-api-python-client==2.87.0
-pandas==2.0.1
-sqlalchemy==2.0.15
-sqlalchemy-cockroachdb==2.0.1
-psycopg2-binary==2.9.6


### PR DESCRIPTION
GitHub actions installs dependencies using `pip` + `requirements.txt`. This seems redundant with `pipenv` and Pipfile*.

Let's just use `pipenv`.

x-ref #33 & #32