### PR TITLE
Fix data workflow action

### DIFF
--- a/.github/workflows/data-workflow.yml
+++ b/.github/workflows/data-workflow.yml
@@ -22,10 +22,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install pipenv --user
-          pipenv install
+          pipenv install --deploy
+        working-directory: ./data-workflow
       - name: Run Workflow
         run: |
-          pipenv run python data-workflow/main.py
+          pipenv run python main.py
+        working-directory: ./data-workflow
 
   data_validation:
     needs: data_workflow
@@ -43,8 +45,10 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r data-validation/requirements.txt
+          python -m pip install pipenv --user
+          pipenv install --deploy
+        working-directory: ./data-validation
       - name: Run Workflow
         run: |
-          python data-validation/main.py
+            pipenv run python main.py
+        working-directory: ./data-validation

--- a/data-validation/requirements.txt
+++ b/data-validation/requirements.txt
@@ -1,4 +1,0 @@
-sqlalchemy==2.0.15
-psycopg2-binary==2.9.6
-sqlalchemy-cockroachdb==2.0.1
-great-expectations==0.18.8


### PR DESCRIPTION
This is the latest attempt to fix the data workflow action.

We'll now run `pipenv` in the proper working directory rather than root.

Also, I made the data-validation config consistent w/ data-workflow to prefer pipenv over requirements.txt

x-ref #34