### PR TITLE
Set an initial value on the workout summary

### DIFF
--- a/slackbot/slackbot/main.py
+++ b/slackbot/slackbot/main.py
@@ -165,6 +165,15 @@ def open_backblast_form(ack, client, command, logger):
                         "element": {
                             "type": "plain_text_input",
                             "multiline": True,
+                            "initial_value": """
+WARMUP:
+
+THE THANG:
+
+MARY:
+
+ANNOUNCEMENTS / COT:
+"""
                             "placeholder": {
                                 "type": "plain_text",
                                 "text": "Workout summary"
@@ -173,7 +182,7 @@ def open_backblast_form(ack, client, command, logger):
                         },
                         "label": {
                             "type": "plain_text",
-                            "text": "Summary",
+                            "text": "Workout Summary",
                             "emoji": True
                         },
                         "optional": True


### PR DESCRIPTION
To gently encourage PAX to write more detailed backblasts, this sets the initial value with a simple outline template.

This was feedback from Churham that PAX sometimes don't know what to write for a backblast workout summary.

Here's the outline:

```
WARMUP:

THE THANG:

MARY:

ANNOUNCEMENTS / COT:

```