### PR TITLE
GCF: set environment to GEN_1

### DIFF
--- a/.github/workflows/gcf.yml
+++ b/.github/workflows/gcf.yml
@@ -50,6 +50,7 @@ jobs:
       uses: google-github-actions/deploy-cloud-functions@main
       with:
         name: ${{ inputs.queue_handler_name }}
+        environment: GEN_1
         entry_point: f3_sheets_handler
         runtime: python39
         region: us-east1
@@ -83,6 +84,7 @@ jobs:
       uses: google-github-actions/deploy-cloud-functions@main
       with:
         name: ${{ inputs.slackbot_name }}
+        environment: GEN_1
         entry_point: slackbot
         runtime: python39
         region: us-east1


### PR DESCRIPTION
I think this will fix deploy errors like [this](https://github.com/f3peakcity/f3_bot/actions/runs/10044018499/job/27758092843#step:6:31
).

Our GCFs exist as GEN_1. The new GH Action defaults to GEN_2, and we're getting an error that the versions are incompatible.

Example error:

```
"error": {
    "code": 400,
    "message": "Function projects/f3-carpex/locations/us-east1/functions/f3-sheets-handler-churham already exists in environment GEN_1, can't change it to GEN_2.",
    "status": "INVALID_ARGUMENT"
```