### PR TITLE
Another pass at fixing deploys

### DIFF
--- a/.github/workflows/deploy-churham.yml
+++ b/.github/workflows/deploy-churham.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - develop
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-greenlevel.yml
+++ b/.github/workflows/deploy-greenlevel.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-peakcity.yml
+++ b/.github/workflows/deploy-peakcity.yml
@@ -3,7 +3,8 @@ name: Deploy Peak City
 on:
   push:
     branches:
-    - main
+      - main
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -14,4 +15,4 @@ jobs:
       queue_handler_name: f3-sheets-handler-peakcity
       env_vars_file: ./env/env-peakcity.yml
     secrets:
-      SLACKBOT_ENV_VARS: '${{ secrets.SLACKBOT_ENV_VARS }}'
+      SLACKBOT_ENV_VARS: "${{ secrets.SLACKBOT_ENV_VARS }}"

--- a/.github/workflows/gcf.yml
+++ b/.github/workflows/gcf.yml
@@ -18,7 +18,6 @@ on:
     secrets:
       SLACKBOT_ENV_VARS:
         required: true
-  workflow_dispatch:
 
 jobs:
   deploy-queue-handler:

--- a/.github/workflows/gcf.yml
+++ b/.github/workflows/gcf.yml
@@ -26,70 +26,67 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
-      contents: 'read'
-      id-token: 'write'
-  
+      contents: "read"
+      id-token: "write"
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - id: 'auth'
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
-      with:
-        workload_identity_provider: 'projects/330812298791/locations/global/workloadIdentityPools/github/providers/github'
-        service_account: 'github-action-runner@f3-carpex.iam.gserviceaccount.com'
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          workload_identity_provider: "projects/330812298791/locations/global/workloadIdentityPools/github/providers/github"
+          service_account: "github-action-runner@f3-carpex.iam.gserviceaccount.com"
 
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v0'
-    
-    - name: Add cockroachdb cert to src folder
-      run: |
-        cp ./root.crt ./sheets_task/src/root.crt
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v0"
 
-    - name: Deploy Queue Handler
-      uses: google-github-actions/deploy-cloud-functions@main
-      with:
-        name: ${{ inputs.queue_handler_name }}
-        environment: GEN_1
-        entry_point: f3_sheets_handler
-        runtime: python39
-        region: us-east1
-        source_dir: ./sheets_task/src
-        env_vars: ${{ secrets.SLACKBOT_ENV_VARS }}
-        env_vars_file: ${{ inputs.env_vars_file }}
+      - name: Add cockroachdb cert to src folder
+        run: |
+          cp ./root.crt ./sheets_task/src/root.crt
+
+      - name: Deploy Queue Handler
+        uses: google-github-actions/deploy-cloud-functions@v2
+        with:
+          name: ${{ inputs.queue_handler_name }}
+          entry_point: f3_sheets_handler
+          runtime: python39
+          region: us-east1
+          source_dir: ./sheets_task/src
+          env_vars: ${{ secrets.SLACKBOT_ENV_VARS }}
+          env_vars_file: ${{ inputs.env_vars_file }}
 
   deploy-slackbot:
     name: Deploy Slackbot
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - id: 'auth'
-      name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v1'
-      with:
-        workload_identity_provider: 'projects/330812298791/locations/global/workloadIdentityPools/github/providers/github'
-        service_account: 'github-action-runner@f3-carpex.iam.gserviceaccount.com'
+      - id: "auth"
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          workload_identity_provider: "projects/330812298791/locations/global/workloadIdentityPools/github/providers/github"
+          service_account: "github-action-runner@f3-carpex.iam.gserviceaccount.com"
 
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v0'
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v0"
 
-    - name: Deploy Slackbot
-      uses: google-github-actions/deploy-cloud-functions@main
-      with:
-        name: ${{ inputs.slackbot_name }}
-        environment: GEN_1
-        entry_point: slackbot
-        memory_mb: 256
-        runtime: python39
-        region: us-east1
-        source_dir: ./slackbot/slackbot
-        env_vars: ${{ secrets.SLACKBOT_ENV_VARS }}
-        env_vars_file: ${{ inputs.env_vars_file }}
+      - name: Deploy Slackbot
+        uses: google-github-actions/deploy-cloud-functions@v2
+        with:
+          name: ${{ inputs.slackbot_name }}
+          entry_point: slackbot
+          runtime: python39
+          region: us-east1
+          source_dir: ./slackbot/slackbot
+          env_vars: ${{ secrets.SLACKBOT_ENV_VARS }}
+          env_vars_file: ${{ inputs.env_vars_file }}


### PR DESCRIPTION
This is another attempt to fix deploys. It downgrades from `google-github-actions/deploy-cloud-functions@main` (currently v3) to `@v2`.

v2 only supports GEN_1 Google Cloud Functions (which we use). v3 defaults to GEN_2, with spotty support for GEN_1.

Upgrading the GCF to GEN_2 is a more fiddly change, and requires access to our Google Cloud account.